### PR TITLE
Add SSE demo page and runner

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SSE Demo</title>
+</head>
+<body>
+  <input id="figmaInput" placeholder="Enter Figma URL" style="width: 80%;" />
+  <script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const es = new EventSource('http://localhost:3333/sse');
+    let endpoint = '';
+    es.onmessage = function (event) {
+      console.log(event.data);
+      if (!endpoint) {
+        try {
+          const data = JSON.parse(event.data);
+          endpoint = data.endpoint || event.data;
+        } catch (e) {
+          endpoint = event.data;
+        }
+      }
+    };
+
+    const input = document.getElementById('figmaInput');
+    input.addEventListener('change', async function () {
+      const value = input.value.trim();
+      if (!value) return;
+      let fileKey = '';
+      let nodeId = '';
+      try {
+        const url = new URL(value);
+        const parts = url.pathname.split('/');
+        const i = parts.indexOf('file');
+        if (i !== -1 && parts.length > i + 1) {
+          fileKey = parts[i + 1];
+        }
+        nodeId = url.searchParams.get('node-id') || '';
+      } catch (e) {
+        console.error('Invalid URL');
+        return;
+      }
+      if (!endpoint) {
+        console.error('No session endpoint received yet');
+        return;
+      }
+      const body = {
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        id: 1,
+        params: {
+          name: 'get_figma_data',
+          arguments: {
+            fileKey,
+            nodeId,
+          },
+        },
+      };
+      try {
+        const res = await fetch(`http://localhost:3333${endpoint}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        const text = await res.text();
+        console.log('API response:', text);
+      } catch (err) {
+        console.error('Request failed', err);
+      }
+    });
+  });
+  </script>
+</body>
+</html>

--- a/open.js
+++ b/open.js
@@ -1,0 +1,7 @@
+import { fileURLToPath } from 'url';
+import path from 'path';
+import open from 'open';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const filePath = path.join(__dirname, 'index.html');
+open(filePath);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "prerelease": "pnpm build",
     "release": "changeset publish && git push --follow-tags",
     "pub:release": "pnpm build && npm publish",
-    "pub:release:beta": "pnpm build && npm publish --tag beta"
+    "pub:release:beta": "pnpm build && npm publish --tag beta",
+    "run:index": "node open.js"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -79,6 +80,7 @@
     "ts-jest": "^29.2.5",
     "tsup": "^8.4.0",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "open": "^10.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- add simple HTML page to connect to local SSE server and send API requests
- provide Node script to open the demo in a browser
- expose `run:index` command and add `open` as dev dependency

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68762d8f3f848328aa572acf1d7245fd